### PR TITLE
dangerously set inner html in style tag

### DIFF
--- a/src/Components/Head.jsx
+++ b/src/Components/Head.jsx
@@ -10,7 +10,7 @@ const Head = ({ css }) => (
         <script async src="https://cdn.ampproject.org/v0.js" />
         {state.elements}
         <style amp-boilerplate="" />
-        <style amp-custom="">{css}</style>
+        <style amp-custom="" dangerouslySetInnerHTML={{ __html: css }} />
       </head>
     )
   }


### PR DESCRIPTION
Since the `css` prop is a string, React will escape characters (https://shripadk.github.io/react/docs/jsx-gotchas.html). This causes issues when you have escapable characters in css, for example:

```js
const Wraper = styled.div`
    background-image: url('https://www.somedomain.com');
`;
```

The output in plain css would be:

```css
.someHash {
   background-image: url(&#x27;https://www.somedomain.com&#x27;);
}
```
By setting the css as `dangerouslySetInnerHTML` the css won't be escaped by React, and the HTML will be rendered with the correct CSS