### PR TITLE
flush hash register

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -18,7 +18,7 @@ const state = {
   elements: [],
 }
 
-const hashRegister = []
+let hashRegister = []
 
 const createElement = (tag, attrs, key) =>
   React.createElement(tag, { ...attrs, key })
@@ -63,6 +63,7 @@ const setOptions = ({
   state.runtimeURI = runtimeURI || state.runtimeURI
   state.extensions = { ...state.extensions, ...extensions }
   state.elements.length = 0
+  hashRegister = []
 }
 
 const { Provider, Consumer } = React.createContext({


### PR DESCRIPTION
Similar to : https://github.com/Ariel-Rodriguez/react-amp-template/issues/15.

When running multiple `renderToString`s for multiple page templates there is a bug which doesn't add new elements to state because they are already present in the `hashRegister` array.

Simply clearing this array when setting options solves this